### PR TITLE
Add Continuous Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,89 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+install: "pip install -r requirements.txt"
+script: py.test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# This is used to install pyschedule locally with pip install -r requirements
+# Used in testing.
+.

--- a/tests/first_test.py
+++ b/tests/first_test.py
@@ -1,4 +1,8 @@
+#!/usr/bin/python
+# coding: utf-8
+import pyschedule
 
 
-def test_simple():
-    assert 1 == 1
+def test_creating_empty_scenario():
+    S = pyschedule.Scenario('Empty')
+    assert S is not None

--- a/tests/first_test.py
+++ b/tests/first_test.py
@@ -1,0 +1,4 @@
+
+
+def test_simple():
+    assert 1 == 1


### PR DESCRIPTION
This adds support for continuous integration using TravisCI. You will need an account (free) at TravisCI.

Produces output like this:
![screen shot 2016-06-04 at 6 42 35 pm](https://cloud.githubusercontent.com/assets/1082033/15802795/dda62cc2-2a84-11e6-9800-30f6bd259101.png)

Which indicates that it fails on Python2.6, but works all the way up to 3.5dev.
