### PR TITLE
Add support for pulp.COIN solver

### DIFF
--- a/src/pyschedule/solvers/mip_pulp.py
+++ b/src/pyschedule/solvers/mip_pulp.py
@@ -79,7 +79,7 @@ class MIP(object):
             self.mip.solve(pl.GLPK_CMD(msg=msg))
         elif kind == 'SCIP':
             self.mip.solve(SCIP_CMD(msg=msg,time_limit=time_limit,ratio_gap=ratio_gap))
-        elif kind == 'CBC':
+        elif kind == 'CBC' or kind == 'COIN':
             options = []
             if time_limit is not None:
                 options.extend(['sec', str(time_limit)])
@@ -88,7 +88,10 @@ class MIP(object):
                 options.extend(['randomCbcSeed', str(random_seed)])
             if ratio_gap is not None:
                 options.extend(['ratio', str(ratio_gap)])
-            self.mip.solve(pl.PULP_CBC_CMD(msg=msg, options=options))
+            if kind == 'CBC':
+                self.mip.solve(pl.PULP_CBC_CMD(msg=msg, options=options))
+            elif kind == 'COIN':
+                self.mip.solve(pl.COIN(msg=msg, options=options))
         else:
             raise Exception('ERROR: solver ' + kind + ' not known')
 


### PR DESCRIPTION
Add support for the [pulp.COIN](https://pythonhosted.org/PuLP/solvers.html#pulp.solvers.COIN) solver that use `cbc` installed on system instead of pulp pre-compiled one.

Motivation: On NixOS, pulp pre-compiled `cbc` cannot find its dependencies and fail to execute.

