### PR TITLE
Fix syntax

### DIFF
--- a/src/pyschedule/pyschedule.py
+++ b/src/pyschedule/pyschedule.py
@@ -1227,7 +1227,7 @@ class _Slice(_SchedElement):
 
 	def __str__(self):
 		param = self._param
-		if self.name is not None and self.name is not '':
+		if self.name is not None and self.name != '':
 			param = self.name
 		slice = ''
 		if self._start is not None or self._end is not None:


### PR DESCRIPTION
When loading pyschedule with Python 3.12 one gets the following syntax warning:
`src/pyschedule/pyschedule.py:1230: SyntaxWarning: "is not" with 'str' literal. Did you mean "!="?`